### PR TITLE
Fix #1 completed

### DIFF
--- a/Sources/Swift-Hotfolder/structs/WatcherConfig.swift
+++ b/Sources/Swift-Hotfolder/structs/WatcherConfig.swift
@@ -25,7 +25,7 @@ public struct WatcherConfig: Codable {
         self.createNonExistingFolders = true
         self.watchInterval = 1.0
         self.maxHotfolderCount = 5
-        self.enumerationOptions = []
+        self.enumerationOptions = [.skipsHiddenFiles]
     }
 
     public static let `default` = WatcherConfig()


### PR DESCRIPTION
- the default  watcherConfig ignores hidden Files
- the enumerationOptions where extended with Codable conformance